### PR TITLE
Add basic auth with netlify edge functions

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,4 @@
+[[edge_functions]]
+path = "/*"
+function = "basic-auth"
+

--- a/netlify/edge-functions/basic-auth.js
+++ b/netlify/edge-functions/basic-auth.js
@@ -1,0 +1,43 @@
+export default async (request, context) => {
+  const username = Netlify.env.get("BASIC_AUTH_USER");
+  const password = Netlify.env.get("BASIC_AUTH_PASS");
+
+  // If env vars are not set, do not block access.
+  if (!username || !password) {
+    return context.next();
+  }
+
+  const unauthorized = () =>
+    new Response("Unauthorized", {
+      status: 401,
+      headers: {
+        "WWW-Authenticate": 'Basic realm="Protected", charset="UTF-8"',
+      },
+    });
+
+  const authHeader = request.headers.get("authorization");
+  if (!authHeader || !authHeader.startsWith("Basic ")) {
+    return unauthorized();
+  }
+
+  try {
+    const base64Credentials = authHeader.slice("Basic ".length).trim();
+    const decoded = atob(base64Credentials);
+    const separatorIndex = decoded.indexOf(":");
+    if (separatorIndex === -1) {
+      return unauthorized();
+    }
+
+    const providedUser = decoded.slice(0, separatorIndex);
+    const providedPass = decoded.slice(separatorIndex + 1);
+
+    if (providedUser === username && providedPass === password) {
+      return context.next();
+    }
+  } catch (_) {
+    return unauthorized();
+  }
+
+  return unauthorized();
+};
+


### PR DESCRIPTION
Add basic auth protection to all routes using Netlify Edge Functions and `BASIC_AUTH_USER`/`BASIC_AUTH_PASS` environment variables.

---
<a href="https://cursor.com/background-agent?bcId=bc-2a48c43e-0486-4f5e-83c3-11663e5e5902">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-2a48c43e-0486-4f5e-83c3-11663e5e5902">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

