### PR TITLE
Add AGENTS.md with Cursor Cloud development instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,27 @@
+## Cursor Cloud specific instructions
+
+This is a **Next.js 16** app (SRT AI Translator) that translates subtitle files using Google Gemini AI. It also has a client-side Time Offset tool that needs no API key.
+
+### Services
+
+| Service | Command | Notes |
+|---------|---------|-------|
+| Dev server | `npm run dev` | Runs on `http://localhost:3000`. Serves both frontend and API routes. |
+
+### Key commands
+
+See `package.json` scripts. Summary:
+
+- **Lint:** `npm run lint`
+- **Build:** `npm run build`
+- **Dev:** `npm run dev`
+
+### Environment variables
+
+Copy `.env.example` to `.env.local`. The only required secret for full functionality is `GOOGLE_GENERATIVE_AI_API_KEY` (Gemini API key). Without it the app loads but translation requests fail; the Time Offset feature still works.
+
+### Gotchas
+
+- The dev command uses `next dev --webpack` (webpack bundler, not Turbopack). Build also uses `--webpack`.
+- The `/api/config` endpoint returns `{"ok":false,...}` when the API key is missing — this is expected behavior, not a bug.
+- `.env.local` is gitignored. Each environment must create its own from `.env.example`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,8 +20,13 @@ See `package.json` scripts. Summary:
 
 Copy `.env.example` to `.env.local`. The only required secret for full functionality is `GOOGLE_GENERATIVE_AI_API_KEY` (Gemini API key). Without it the app loads but translation requests fail; the Time Offset feature still works.
 
+### Hello world task
+
+Without a Gemini API key, use the **Time Offset** feature as the hello world task: upload any `.srt` file, apply a millisecond offset, and verify the downloaded file has shifted timestamps. This exercises the app's core SRT-processing logic entirely client-side.
+
 ### Gotchas
 
 - The dev command uses `next dev --webpack` (webpack bundler, not Turbopack). Build also uses `--webpack`.
 - The `/api/config` endpoint returns `{"ok":false,...}` when the API key is missing — this is expected behavior, not a bug.
 - `.env.local` is gitignored. Each environment must create its own from `.env.example`.
+- When no `GOOGLE_GENERATIVE_AI_API_KEY` is set, the UI may show a config error banner on the Translate tab. This is expected — dismiss or ignore it and use the Time Offset tab instead.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds `AGENTS.md` with Cursor Cloud-specific development instructions for future cloud agents, including:

- Service overview and key commands (lint, build, dev)
- Environment variable setup guidance
- Hello world task guidance (Time Offset feature, works without API key)
- Non-obvious gotchas (webpack bundler flag, expected `/api/config` behavior without API key, gitignored `.env.local`)

### Development environment verification

All checks pass:

| Check | Result |
|-------|--------|
| `npm run lint` | Clean |
| `npm run build` | Compiled successfully (4 routes) |
| `npm run dev` | Dev server on `http://localhost:3000`, HTTP 200 |
| `/api/config` endpoint | Returns expected JSON |
| Time Offset tool (hello world) | Uploaded SRT, applied +2000ms offset, verified downloaded file |

### Hello world demo

[hello_world_time_offset.mp4](https://cursor.com/agents/bc-058d93d2-9c43-4ebd-a3b7-e25e4d3bdee3/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhello_world_time_offset.mp4)

Uploaded a 3-entry SRT file, applied +2000ms offset, verified all timestamps shifted correctly in the downloaded file.

[Time offset applied successfully](https://cursor.com/agents/bc-058d93d2-9c43-4ebd-a3b7-e25e4d3bdee3/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhello_world_success.webp)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-058d93d2-9c43-4ebd-a3b7-e25e4d3bdee3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-058d93d2-9c43-4ebd-a3b7-e25e4d3bdee3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

