### PR TITLE
Hide per-file progress bars after translation completes

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -263,8 +263,7 @@ function FileProgressRow({ result }: { result: FileResult }) {
 		result.totalBatches > 0
 			? toPercent(result.completedBatches, result.totalBatches)
 			: 0;
-	const isDone = result.status === "success";
-	const isFailed = result.status === "failed";
+	const isTranslating = result.status === "translating";
 	const batchLabel =
 		result.totalBatches > 0
 			? `${Math.min(result.completedBatches, result.totalBatches)}/${result.totalBatches} batches`
@@ -275,21 +274,16 @@ function FileProgressRow({ result }: { result: FileResult }) {
 				<p className="truncate text-sm font-medium text-slate-700">{result.filename}</p>
 				<p className="mt-1 text-xs text-slate-500">{batchLabel}</p>
 			</div>
-			<div className="w-36 shrink-0">
-				<div className="h-2 rounded-full bg-slate-200">
-					<div
-						className={classNames(
-							"h-full rounded-full transition-all duration-300",
-							isFailed
-								? "bg-rose-400"
-								: isDone
-									? "bg-emerald-500"
-									: "bg-gradient-to-r from-cyan-500 to-indigo-500",
-						)}
-						style={{ width: `${isDone ? 100 : percentage}%` }}
-					/>
+			{isTranslating && (
+				<div className="w-36 shrink-0">
+					<div className="h-2 rounded-full bg-slate-200">
+						<div
+							className="h-full rounded-full bg-gradient-to-r from-cyan-500 to-indigo-500 transition-all duration-300"
+							style={{ width: `${percentage}%` }}
+						/>
+					</div>
 				</div>
-			</div>
+			)}
 			<span
 				title={result.status === "failed" ? result.error || "" : ""}
 				className={classNames(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- update `FileProgressRow` so the per-file progress bar is rendered only while a file is actively translating
- keep per-file status badges visible for all states (`pending`, `translating`, `success`, `failed`)
- remove success/failed bar color logic since completed and failed rows no longer render a progress bar

## Testing
- `npm run lint`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d9562227-d834-4ddf-957b-23af293e1b80"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d9562227-d834-4ddf-957b-23af293e1b80"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

