### PR TITLE
Handle blocked Gemini responses with adaptive split fallback

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,3 +3,8 @@ GEMINI_MODEL_NAME=gemini-3-flash-preview
 GEMINI_BATCH_TOKENS=350
 GEMINI_THINKING_LEVEL=low
 TRANSLATION_MAX_PARALLEL=5
+
+# Prohibited content handling (non-configurable safety blocks)
+# PROHIBITED_CONTENT_POLICY=keep_original
+# PROHIBITED_CONTENT_PLACEHOLDER=[Content not available]
+# PROHIBITED_CONTENT_MAX_SPLIT_DEPTH=5

--- a/app/api/config/route.ts
+++ b/app/api/config/route.ts
@@ -18,6 +18,9 @@ export async function GET() {
 			maxParallel: config.maxParallel,
 			thinkingLevel: config.thinkingLevel,
 			isGemini3Model: config.isGemini3Model,
+			prohibitedContentPolicy: config.prohibitedContentPolicy,
+			prohibitedContentPlaceholder: config.prohibitedContentPlaceholder,
+			maxSplitDepth: config.maxSplitDepth,
 		}),
 		{
 			headers: { "Content-Type": "application/json" },

--- a/app/api/route.ts
+++ b/app/api/route.ts
@@ -1,6 +1,22 @@
-import { groupSegmentsByTokenLength } from "@/lib/srt";
 import { parseSegment } from "@/lib/client";
+import {
+	applyIrreducibleBlockPolicy,
+	attachTranslationErrorInfo,
+	classifyFinishReason,
+	classifyTranslationError,
+	getTranslationErrorInfo,
+	translationErrorCategoryToCode,
+} from "@/lib/content-block-handler";
+import { groupSegmentsByTokenLength } from "@/lib/srt";
 import { resolveTranslationRuntimeConfig } from "@/lib/translation-config";
+import type {
+	ProhibitedContentPolicy,
+	Segment,
+	TranslatedSegmentResult,
+	TranslationErrorCategory,
+	TranslationErrorInfo,
+	TranslationGroupResult,
+} from "@/types";
 import { google } from "@ai-sdk/google";
 import { generateText } from "ai";
 
@@ -11,6 +27,28 @@ export const maxDuration = 300;
 const MAX_RETRIES = 3;
 const MODEL_CALL_TIMEOUT_MS = 55_000;
 const SEGMENT_BLOCK_SPLIT_REGEX = /\r?\n\s*\r?\n/;
+const BASE_SERVER_BACKOFF_DELAY_MS = 1_000;
+const MAX_SERVER_BACKOFF_DELAY_MS = 8_000;
+
+type TranslationRequestContext = {
+	runId: string;
+	batchLabel: string;
+	groupIndex: number;
+	totalGroups: number;
+	modelName: string;
+	thinkingLevel: "minimal" | "low" | "medium" | "high";
+	isGemini3Model: boolean;
+};
+
+type TranslationFallbackConfig = {
+	policy: ProhibitedContentPolicy;
+	placeholder: string;
+	maxSplitDepth: number;
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return Boolean(value) && typeof value === "object";
+}
 
 function escapeRegExp(value: string): string {
 	return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
@@ -129,27 +167,109 @@ function toErrorLog(error: unknown): Record<string, unknown> {
 	return details;
 }
 
-type TranslationRequestContext = {
-	runId: string;
-	batchLabel: string;
-	groupIndex: number;
-	totalGroups: number;
-	translationDelimiter: string;
-	modelName: string;
-	thinkingLevel: "minimal" | "low" | "medium" | "high";
-	isGemini3Model: boolean;
-};
+function getServerRetryDelayMs(attempt: number): number {
+	const exponentialDelay = BASE_SERVER_BACKOFF_DELAY_MS * 2 ** (attempt - 1);
+	const jitter = Math.floor(Math.random() * 250);
+	return Math.min(MAX_SERVER_BACKOFF_DELAY_MS, exponentialDelay + jitter);
+}
+
+function getMaxAttemptsForCategory(category: TranslationErrorCategory): number {
+	if (category === "segment_mismatch" || category === "unknown") {
+		return 2;
+	}
+	return MAX_RETRIES;
+}
+
+function extractProviderResponseIdFromResult(response: unknown): string | undefined {
+	if (!isRecord(response)) {
+		return undefined;
+	}
+
+	const directId = response.id;
+	if (typeof directId === "string") {
+		return directId;
+	}
+
+	const responseMetadata = response.response;
+	if (!isRecord(responseMetadata)) {
+		return undefined;
+	}
+
+	return typeof responseMetadata.id === "string" ? responseMetadata.id : undefined;
+}
+
+function buildErrorMessage(info: TranslationErrorInfo): string {
+	switch (info.category) {
+		case "prohibited_content":
+		case "safety_filter":
+		case "content_filter":
+		case "prompt_blocked":
+			return "Translation blocked due to content restrictions.";
+		case "timeout":
+			return "Translation request timed out. Please retry.";
+		case "segment_mismatch":
+			return "Translation output was invalid. Please retry.";
+		case "transient":
+		case "network":
+			return "Translation provider is temporarily unavailable. Please retry.";
+		case "unknown":
+		default:
+			return "Error during translation";
+	}
+}
+
+function toJsonResponse(
+	body: Record<string, unknown>,
+	status: number,
+	runId: string,
+): Response {
+	return new Response(JSON.stringify(body), {
+		status,
+		headers: {
+			"Content-Type": "application/json",
+			"x-translation-run-id": runId,
+		},
+	});
+}
+
+function mergeGroupResults(
+	leftResult: TranslationGroupResult,
+	rightResult: TranslationGroupResult,
+	depth: number,
+): TranslationGroupResult {
+	const blockedSegmentIds = Array.from(
+		new Set([...leftResult.blockedSegmentIds, ...rightResult.blockedSegmentIds]),
+	);
+	const blockedReasons = Array.from(
+		new Set([...leftResult.blockedReasons, ...rightResult.blockedReasons]),
+	);
+
+	return {
+		segments: [...leftResult.segments, ...rightResult.segments],
+		hasBlockedSegments: blockedSegmentIds.length > 0,
+		blockedSegmentIds,
+		blockedReasons,
+		splitDepth: Math.max(depth, leftResult.splitDepth, rightResult.splitDepth),
+	};
+}
 
 const retrieveTranslation = async (
-	text: string,
+	segments: Segment[],
 	language: string,
-	expectedSegments: number,
 	context: TranslationRequestContext,
+	depth: number,
 ): Promise<string[]> => {
+	const expectedSegments = segments.length;
+	const segmentIds = segments.map((segment) => segment.id);
+
 	for (let attempt = 1; attempt <= MAX_RETRIES; attempt += 1) {
 		const attemptStartedAt = Date.now();
 		const abortController = new AbortController();
 		const timeoutId = setTimeout(() => abortController.abort(), MODEL_CALL_TIMEOUT_MS);
+		const translationDelimiter = `|||SRT_SEGMENT_${crypto
+			.randomUUID()
+			.replace(/-/g, "")}|||`;
+		const text = segments.map((segment) => segment.text).join(translationDelimiter);
 
 		console.info(
 			`[translate][${context.runId}] Batch ${context.batchLabel} group ${context.groupIndex}/${context.totalGroups} attempt ${attempt}/${MAX_RETRIES} started`,
@@ -159,11 +279,13 @@ const retrieveTranslation = async (
 				model: context.modelName,
 				thinkingLevel: context.thinkingLevel,
 				isGemini3Model: context.isGemini3Model,
+				splitDepth: depth,
+				segmentIds,
 			},
 		);
 
 		try {
-			const { text: translatedText } = await generateText({
+			const result = await generateText({
 				model: google(context.modelName),
 				...(context.isGemini3Model
 					? {
@@ -199,11 +321,11 @@ const retrieveTranslation = async (
 							- If a segment has multiple lines (for example, dialogue turns), keep the same line order and line-break structure.
 							- Preserve punctuation style and emphasis (including dashes for dialogue turns).
 
-							The input text contains ${expectedSegments} subtitle segments separated by "${context.translationDelimiter}".
-							Return exactly ${expectedSegments} translated segments in the same order, separated only by "${context.translationDelimiter}".
+							The input text contains ${expectedSegments} subtitle segments separated by "${translationDelimiter}".
+							Return exactly ${expectedSegments} translated segments in the same order, separated only by "${translationDelimiter}".
 							Output only translated segment text.
 							Never add numbering, timestamps, markdown, code fences, or explanations.
-							Never include "${context.translationDelimiter}" inside any translated segment.`,
+							Never include "${translationDelimiter}" inside any translated segment.`,
 					},
 					{
 						role: "user",
@@ -212,8 +334,36 @@ const retrieveTranslation = async (
 				],
 			});
 
+			const providerResponseId = extractProviderResponseIdFromResult(
+				(result as { response?: unknown }).response,
+			);
+			const finishReasonInfo = classifyFinishReason(
+				typeof result.finishReason === "string" ? result.finishReason : undefined,
+				providerResponseId,
+			);
+			if (finishReasonInfo) {
+				console.warn(
+					`[translate][${context.runId}] Batch ${context.batchLabel} group ${context.groupIndex}/${context.totalGroups} finishReason non-normal`,
+					{
+						splitDepth: depth,
+						finishReason: finishReasonInfo.blockReason,
+						segmentCount: expectedSegments,
+						segmentIds,
+						providerResponseId: finishReasonInfo.providerResponseId,
+					},
+				);
+				throw attachTranslationErrorInfo(
+					new Error(`Blocked finishReason: ${finishReasonInfo.blockReason}`),
+					finishReasonInfo,
+				);
+			}
+
+			if (!result.text || !result.text.trim()) {
+				throw new Error("Model returned empty translation output.");
+			}
+
 			const translatedSegments = normalizeTranslatedSegmentCount(
-				splitTranslatedSegments(translatedText, context.translationDelimiter),
+				splitTranslatedSegments(result.text, translationDelimiter),
 				expectedSegments,
 			);
 
@@ -227,34 +377,214 @@ const retrieveTranslation = async (
 				`[translate][${context.runId}] Batch ${context.batchLabel} group ${context.groupIndex}/${context.totalGroups} attempt ${attempt}/${MAX_RETRIES} succeeded`,
 				{
 					durationMs: Date.now() - attemptStartedAt,
-					outputChars: translatedText.length,
+					outputChars: result.text.length,
 					outputSegments: translatedSegments.length,
+					splitDepth: depth,
 				},
 			);
 
 			return translatedSegments;
 		} catch (error) {
+			const classified = classifyTranslationError(error);
+			console.info(`[translate][${context.runId}] error classified`, {
+				batchLabel: context.batchLabel,
+				groupIndex: context.groupIndex,
+				category: classified.category,
+				retryable: classified.retryable,
+				splittable: classified.splittable,
+				blockReason: classified.blockReason,
+				providerResponseId: classified.providerResponseId,
+			});
+
 			console.error(
 				`[translate][${context.runId}] Batch ${context.batchLabel} group ${context.groupIndex}/${context.totalGroups} attempt ${attempt}/${MAX_RETRIES} failed`,
 				{
 					durationMs: Date.now() - attemptStartedAt,
+					splitDepth: depth,
+					category: classified.category,
 					...toErrorLog(error),
 				},
 			);
-			if (attempt < MAX_RETRIES) {
-				console.warn(
-					`[translate][${context.runId}] Batch ${context.batchLabel} group ${context.groupIndex}/${context.totalGroups} retrying in 1000ms`,
-				);
-				await sleep(1000);
-				continue;
+
+			if (!classified.retryable) {
+				throw attachTranslationErrorInfo(error, classified);
 			}
-			throw error;
+
+			const maxAttemptsForCategory = getMaxAttemptsForCategory(classified.category);
+			if (attempt >= maxAttemptsForCategory) {
+				throw attachTranslationErrorInfo(error, classified);
+			}
+
+			const retryDelayMs = getServerRetryDelayMs(attempt);
+			console.warn(
+				`[translate][${context.runId}] Batch ${context.batchLabel} group ${context.groupIndex}/${context.totalGroups} retrying in ${retryDelayMs}ms`,
+				{
+					category: classified.category,
+					attempt,
+					maxAttemptsForCategory,
+				},
+			);
+			await sleep(retryDelayMs);
 		} finally {
 			clearTimeout(timeoutId);
 		}
 	}
 
-	return [];
+	throw new Error("Translation failed after retries.");
+};
+
+const retrieveTranslationWithFallback = async (
+	segments: Segment[],
+	language: string,
+	context: TranslationRequestContext,
+	fallbackConfig: TranslationFallbackConfig,
+	depth = 0,
+): Promise<TranslationGroupResult> => {
+	const startedAt = Date.now();
+	try {
+		const translated = await retrieveTranslation(segments, language, context, depth);
+		const translatedSegments: TranslatedSegmentResult[] = translated.map(
+			(segmentText, index) => ({
+				text: segmentText,
+				blocked: false,
+				originalSegmentId: segments[index]?.id ?? index + 1,
+			}),
+		);
+		return {
+			segments: translatedSegments,
+			hasBlockedSegments: false,
+			blockedSegmentIds: [],
+			blockedReasons: [],
+			splitDepth: depth,
+		};
+	} catch (error) {
+		const classified = getTranslationErrorInfo(error) ?? classifyTranslationError(error);
+		const segmentIds = segments.map((segment) => segment.id);
+
+		console.info(`[translate][${context.runId}] error classified`, {
+			batchLabel: context.batchLabel,
+			groupIndex: context.groupIndex,
+			category: classified.category,
+			retryable: classified.retryable,
+			splittable: classified.splittable,
+			blockReason: classified.blockReason,
+			providerResponseId: classified.providerResponseId,
+			splitDepth: depth,
+		});
+
+		if (!classified.splittable) {
+			throw attachTranslationErrorInfo(error, classified);
+		}
+
+		console.warn(
+			`[translate][${context.runId}] content blocked`,
+			{
+				batchLabel: context.batchLabel,
+				groupIndex: context.groupIndex,
+				category: classified.category,
+				blockReason: classified.blockReason,
+				segmentIds,
+				segmentCount: segments.length,
+				splitDepth: depth,
+				providerResponseId: classified.providerResponseId,
+			},
+		);
+
+		if (segments.length === 1) {
+			const blockedSegment = applyIrreducibleBlockPolicy(
+				segments[0],
+				fallbackConfig.policy,
+				fallbackConfig.placeholder,
+				classified.blockReason,
+			);
+			console.warn(`[translate][${context.runId}] irreducible block`, {
+				batchLabel: context.batchLabel,
+				groupIndex: context.groupIndex,
+				segmentId: segments[0].id,
+				category: classified.category,
+				blockReason: classified.blockReason,
+				policy: fallbackConfig.policy,
+				originalTextLength: segments[0].text.length,
+				splitDepth: depth,
+			});
+			return {
+				segments: [blockedSegment],
+				hasBlockedSegments: true,
+				blockedSegmentIds: [segments[0].id],
+				blockedReasons: classified.blockReason ? [classified.blockReason] : [],
+				splitDepth: depth,
+			};
+		}
+
+		if (depth >= fallbackConfig.maxSplitDepth) {
+			console.warn(`[translate][${context.runId}] split depth limit reached`, {
+				batchLabel: context.batchLabel,
+				groupIndex: context.groupIndex,
+				maxSplitDepth: fallbackConfig.maxSplitDepth,
+				segmentCount: segments.length,
+				segmentIds,
+				category: classified.category,
+				blockReason: classified.blockReason,
+			});
+			const blockedSegments = segments.map((segment) =>
+				applyIrreducibleBlockPolicy(
+					segment,
+					fallbackConfig.policy,
+					fallbackConfig.placeholder,
+					classified.blockReason,
+				),
+			);
+			return {
+				segments: blockedSegments,
+				hasBlockedSegments: true,
+				blockedSegmentIds: segmentIds,
+				blockedReasons: classified.blockReason ? [classified.blockReason] : [],
+				splitDepth: depth,
+			};
+		}
+
+		const middleIndex = Math.ceil(segments.length / 2);
+		const leftSegments = segments.slice(0, middleIndex);
+		const rightSegments = segments.slice(middleIndex);
+
+		console.info(`[translate][${context.runId}] splitting group`, {
+			batchLabel: context.batchLabel,
+			groupIndex: context.groupIndex,
+			originalSize: segments.length,
+			leftSize: leftSegments.length,
+			rightSize: rightSegments.length,
+			depth,
+			segmentIds,
+		});
+
+		const leftResult = await retrieveTranslationWithFallback(
+			leftSegments,
+			language,
+			context,
+			fallbackConfig,
+			depth + 1,
+		);
+		const rightResult = await retrieveTranslationWithFallback(
+			rightSegments,
+			language,
+			context,
+			fallbackConfig,
+			depth + 1,
+		);
+
+		const merged = mergeGroupResults(leftResult, rightResult, depth);
+		if (depth === 0) {
+			console.info(`[translate][${context.runId}] split fallback complete`, {
+				batchLabel: context.batchLabel,
+				groupIndex: context.groupIndex,
+				totalSegments: segments.length,
+				blockedCount: merged.blockedSegmentIds.length,
+				splitDepth: merged.splitDepth,
+				durationMs: Date.now() - startedAt,
+			});
+		}
+		return merged;
+	}
 };
 
 export async function POST(request: Request) {
@@ -278,50 +608,39 @@ export async function POST(request: Request) {
 
 	try {
 		if (!process.env.GOOGLE_GENERATIVE_AI_API_KEY) {
-			return new Response(
-				JSON.stringify({
+			return toJsonResponse(
+				{
 					error:
 						"Missing GOOGLE_GENERATIVE_AI_API_KEY. Set it in Netlify env or .env.local.",
+					code: "CONFIG_ERROR",
 					runId,
-				}),
-				{
-					status: 500,
-					headers: {
-						"Content-Type": "application/json",
-						"x-translation-run-id": runId,
-					},
 				},
+				500,
+				runId,
 			);
 		}
 		if (runtimeConfigError) {
-			return new Response(
-				JSON.stringify({
-					error: runtimeConfigError,
-					runId,
-				}),
+			return toJsonResponse(
 				{
-					status: 500,
-					headers: {
-						"Content-Type": "application/json",
-						"x-translation-run-id": runId,
-					},
+					error: runtimeConfigError,
+					code: "CONFIG_ERROR",
+					runId,
 				},
+				500,
+				runId,
 			);
 		}
+
 		const payload = parsePayload(await request.json().catch(() => null));
 		if (!payload) {
-			return new Response(
-				JSON.stringify({
-					error: "Invalid request. Expected content and language.",
-					runId,
-				}),
+			return toJsonResponse(
 				{
-					status: 400,
-					headers: {
-						"Content-Type": "application/json",
-						"x-translation-run-id": runId,
-					},
+					error: "Invalid request. Expected content and language.",
+					code: "INVALID_REQUEST",
+					runId,
 				},
+				400,
+				runId,
 			);
 		}
 
@@ -334,6 +653,8 @@ export async function POST(request: Request) {
 			thinkingLevel: runtimeConfig.thinkingLevel,
 			isGemini3Model: runtimeConfig.isGemini3Model,
 			maxTokensPerRequest: runtimeConfig.maxTokensPerRequest,
+			prohibitedContentPolicy: runtimeConfig.prohibitedContentPolicy,
+			maxSplitDepth: runtimeConfig.maxSplitDepth,
 		});
 
 		const segments = content
@@ -347,18 +668,14 @@ export async function POST(request: Request) {
 			}));
 
 		if (!segments.length) {
-			return new Response(
-				JSON.stringify({
-					error: "No valid SRT segments found in request content.",
-					runId,
-				}),
+			return toJsonResponse(
 				{
-					status: 400,
-					headers: {
-						"Content-Type": "application/json",
-						"x-translation-run-id": runId,
-					},
+					error: "No valid SRT segments found in request content.",
+					code: "INVALID_REQUEST",
+					runId,
 				},
+				400,
+				runId,
 			);
 		}
 
@@ -372,79 +689,126 @@ export async function POST(request: Request) {
 			maxTokensPerRequest: runtimeConfig.maxTokensPerRequest,
 		});
 
-		let currentIndex = 0;
-		const encoder = new TextEncoder();
+		const translatedBlocks: string[] = [];
+		const blockedSegmentIds: number[] = [];
+		const blockedReasons = new Set<string>();
+		let outputSegments = 0;
 
-		const stream = new ReadableStream({
-			async start(controller) {
-				const streamStartedAt = Date.now();
-				try {
-					for (let groupIndex = 0; groupIndex < groups.length; groupIndex += 1) {
-						const group = groups[groupIndex];
-						const translationDelimiter = `|||SRT_SEGMENT_${crypto
-							.randomUUID()
-							.replace(/-/g, "")}|||`;
-						const text = group.map((segment) => segment.text).join(translationDelimiter);
-						const translatedSegments = await retrieveTranslation(
-							text,
-							language,
-							group.length,
-							{
-								runId,
-								batchLabel,
-								groupIndex: groupIndex + 1,
-								totalGroups: groups.length,
-								translationDelimiter,
-								modelName: runtimeConfig.modelName,
-								thinkingLevel: runtimeConfig.thinkingLevel,
-								isGemini3Model: runtimeConfig.isGemini3Model,
-							},
-						);
+		for (let groupIndex = 0; groupIndex < groups.length; groupIndex += 1) {
+			const group = groups[groupIndex];
+			const groupResult = await retrieveTranslationWithFallback(
+				group,
+				language,
+				{
+					runId,
+					batchLabel,
+					groupIndex: groupIndex + 1,
+					totalGroups: groups.length,
+					modelName: runtimeConfig.modelName,
+					thinkingLevel: runtimeConfig.thinkingLevel,
+					isGemini3Model: runtimeConfig.isGemini3Model,
+				},
+				{
+					policy: runtimeConfig.prohibitedContentPolicy,
+					placeholder: runtimeConfig.prohibitedContentPlaceholder,
+					maxSplitDepth: runtimeConfig.maxSplitDepth,
+				},
+			);
 
-						for (const segment of translatedSegments) {
-							const originalSegment = segments[currentIndex];
-							currentIndex += 1;
-							if (!originalSegment) {
-								continue;
-							}
+			if (groupResult.segments.length !== group.length) {
+				throw new Error(
+					`Unexpected translated output shape. Expected ${group.length} segments, received ${groupResult.segments.length}.`,
+				);
+			}
 
-							const srt = `${originalSegment.id}\n${originalSegment.timestamp}\n${segment.trim()}\n\n`;
-							controller.enqueue(encoder.encode(srt));
-						}
-					}
+			for (let segmentIndex = 0; segmentIndex < group.length; segmentIndex += 1) {
+				const originalSegment = group[segmentIndex];
+				const translatedSegment = groupResult.segments[segmentIndex];
+				const translatedText = translatedSegment?.text?.trim() ?? "";
+				translatedBlocks.push(
+					`${originalSegment.id}\n${originalSegment.timestamp}\n${translatedText}\n\n`,
+				);
+				outputSegments += 1;
 
-					console.info(`[translate][${runId}] Batch ${batchLabel} streamed`, {
-						durationMs: Date.now() - streamStartedAt,
-						outputSegments: currentIndex,
-					});
-					controller.close();
-				} catch (streamError) {
-					console.error(`[translate][${runId}] Batch ${batchLabel} stream error`, {
-						...toErrorLog(streamError),
-					});
-					controller.error(streamError);
+				if (translatedSegment?.blocked) {
+					blockedSegmentIds.push(originalSegment.id);
 				}
-			},
+				if (translatedSegment?.blockReason) {
+					blockedReasons.add(translatedSegment.blockReason);
+				}
+			}
+
+			if (groupResult.hasBlockedSegments) {
+				console.info(`[translate][${runId}] batch partial success`, {
+					batchLabel,
+					groupIndex: groupIndex + 1,
+					totalSegments: group.length,
+					translatedCount:
+						group.length - groupResult.blockedSegmentIds.length,
+					blockedCount: groupResult.blockedSegmentIds.length,
+					blockedSegmentIds: groupResult.blockedSegmentIds,
+					blockReasons: groupResult.blockedReasons,
+				});
+			}
+		}
+
+		if (outputSegments !== segments.length) {
+			throw new Error(
+				`Unexpected translated output shape. Expected ${segments.length} segments, received ${outputSegments}.`,
+			);
+		}
+
+		const uniqueBlockedSegmentIds = Array.from(new Set(blockedSegmentIds));
+		const translationStatus = uniqueBlockedSegmentIds.length > 0 ? "partial" : "complete";
+		const headers: Record<string, string> = {
+			"Content-Type": "text/plain; charset=utf-8",
+			"Cache-Control": "no-store",
+			"x-translation-run-id": runId,
+			"x-translation-status": translationStatus,
+		};
+
+		if (uniqueBlockedSegmentIds.length > 0) {
+			headers["x-translation-blocked-segments"] = uniqueBlockedSegmentIds.join(",");
+		}
+		if (blockedReasons.size > 0) {
+			headers["x-translation-blocked-reasons"] = Array.from(blockedReasons).join(",");
+		}
+
+		console.info(`[translate][${runId}] Batch ${batchLabel} completed`, {
+			durationMs: Date.now() - batchStartedAt,
+			outputSegments,
+			status: translationStatus,
+			blockedCount: uniqueBlockedSegmentIds.length,
+			blockedSegmentIds: uniqueBlockedSegmentIds,
+			blockReasons: Array.from(blockedReasons),
 		});
 
-		return new Response(stream, {
-			headers: {
-				"Content-Type": "text/plain; charset=utf-8",
-				"Cache-Control": "no-store",
-				"x-translation-run-id": runId,
-			},
+		return new Response(translatedBlocks.join(""), {
+			headers,
 		});
 	} catch (error) {
+		const classified = getTranslationErrorInfo(error) ?? classifyTranslationError(error);
+		const code = translationErrorCategoryToCode(classified.category);
+		const status = classified.category === "timeout" ? 504 : 500;
+		const responseBody: Record<string, unknown> = {
+			error: buildErrorMessage(classified),
+			code,
+			runId,
+		};
+		if (classified.blockReason) {
+			responseBody.blockReasons = [classified.blockReason];
+		}
+
 		console.error(`[translate][${runId}] Batch ${batchLabel} failed`, {
 			durationMs: Date.now() - batchStartedAt,
+			category: classified.category,
+			retryable: classified.retryable,
+			splittable: classified.splittable,
+			blockReason: classified.blockReason,
+			providerResponseId: classified.providerResponseId,
 			...toErrorLog(error),
 		});
-		return new Response(JSON.stringify({ error: "Error during translation", runId }), {
-			status: 500,
-			headers: {
-				"Content-Type": "application/json",
-				"x-translation-run-id": runId,
-			},
-		});
+
+		return toJsonResponse(responseBody, status, runId);
 	}
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -22,6 +22,12 @@ const BASE_BACKOFF_DELAY_MS = 1000;
 const MAX_BACKOFF_DELAY_MS = 12000;
 const INTER_BATCH_DELAY_MS = 150;
 const RETRIABLE_STATUS_CODES = new Set([408, 425, 429, 500, 502, 503, 504]);
+const CONTENT_BLOCK_ERROR_CODES = new Set([
+	"PROHIBITED_CONTENT",
+	"SAFETY_FILTER",
+	"CONTENT_FILTER",
+	"PROMPT_BLOCKED",
+]);
 const DEFAULT_MAX_PARALLEL = 5;
 const MIN_MAX_PARALLEL = 1;
 const MAX_MAX_PARALLEL = 20;
@@ -36,8 +42,16 @@ type FileResult = {
 	translatedContent?: string;
 	outputFilename?: string;
 	error?: string;
+	retryable?: boolean;
+	blockedSegmentIds?: number[];
+	isPartialTranslation?: boolean;
 	totalBatches: number;
 	completedBatches: number;
+};
+
+type BatchRequestError = Error & {
+	code?: string;
+	nonRetryable?: boolean;
 };
 
 type BulkProgress = {
@@ -83,6 +97,28 @@ function isRetriableStatus(status: number): boolean {
 	return RETRIABLE_STATUS_CODES.has(status);
 }
 
+function isContentBlockErrorCode(code: unknown): boolean {
+	return typeof code === "string" && CONTENT_BLOCK_ERROR_CODES.has(code);
+}
+
+function createBatchRequestError(
+	message: string,
+	options?: { code?: string; nonRetryable?: boolean },
+): BatchRequestError {
+	const error = new Error(message) as BatchRequestError;
+	if (options?.code) {
+		error.code = options.code;
+	}
+	if (options?.nonRetryable) {
+		error.nonRetryable = true;
+	}
+	return error;
+}
+
+function isBatchRequestError(error: unknown): error is BatchRequestError {
+	return error instanceof Error;
+}
+
 function getRetryDelayMs(attempt: number): number {
 	const exponentialDelay = BASE_BACKOFF_DELAY_MS * 2 ** (attempt - 1);
 	const jitter = Math.floor(Math.random() * 250);
@@ -112,6 +148,10 @@ async function requestTranslationBatch(
 				},
 			});
 		} catch (error) {
+			if (isBatchRequestError(error) && error.nonRetryable) {
+				throw error;
+			}
+
 			lastError =
 				error instanceof Error
 					? error
@@ -134,10 +174,33 @@ async function requestTranslationBatch(
 		}
 
 		const errorText = await response.text().catch(() => "");
+		let errorBody: Record<string, unknown> | null = null;
+		if (errorText) {
+			try {
+				const parsed = JSON.parse(errorText) as unknown;
+				if (parsed && typeof parsed === "object") {
+					errorBody = parsed as Record<string, unknown>;
+				}
+			} catch {
+				errorBody = null;
+			}
+		}
+
+		const code = typeof errorBody?.code === "string" ? errorBody.code : undefined;
+		const serverMessage =
+			typeof errorBody?.error === "string" ? errorBody.error : undefined;
 		const errorMessage =
+			serverMessage ||
 			errorText ||
 			`Translation request batch ${requestNumber} failed with status ${response.status}.`;
-		lastError = new Error(errorMessage);
+		lastError = createBatchRequestError(errorMessage, {
+			code,
+			nonRetryable: isContentBlockErrorCode(code),
+		});
+
+		if (isContentBlockErrorCode(code)) {
+			throw lastError;
+		}
 
 		if (!isRetriableStatus(response.status) || attempt === MAX_BATCH_RETRIES) {
 			throw lastError;
@@ -264,6 +327,7 @@ function FileProgressRow({ result }: { result: FileResult }) {
 			? toPercent(result.completedBatches, result.totalBatches)
 			: 0;
 	const isTranslating = result.status === "translating";
+	const blockedCount = result.blockedSegmentIds?.length ?? 0;
 	const batchLabel =
 		result.totalBatches > 0
 			? `${Math.min(result.completedBatches, result.totalBatches)}/${result.totalBatches} batches`
@@ -273,6 +337,12 @@ function FileProgressRow({ result }: { result: FileResult }) {
 			<div className="min-w-0 flex-1">
 				<p className="truncate text-sm font-medium text-slate-700">{result.filename}</p>
 				<p className="mt-1 text-xs text-slate-500">{batchLabel}</p>
+				{result.status === "success" && blockedCount > 0 && (
+					<p className="mt-1 text-xs text-amber-700">
+						{blockedCount} segment{blockedCount === 1 ? "" : "s"} used fallback text
+						due to content restrictions.
+					</p>
+				)}
 			</div>
 			{isTranslating && (
 				<div className="w-36 shrink-0">
@@ -390,11 +460,24 @@ export default function Home() {
 	async function handleStream(response: Response): Promise<{
 		content: string;
 		translatedSegmentCount: number;
+		blockedSegmentIds: number[];
+		isPartial: boolean;
 	}> {
 		const data = response.body;
 		if (!data) {
 			throw new Error("Translation response body is missing.");
 		}
+
+		const blockedSegmentsHeader = response.headers.get(
+			"x-translation-blocked-segments",
+		);
+		const blockedSegmentIds = blockedSegmentsHeader
+			? blockedSegmentsHeader
+					.split(",")
+					.map((segmentId) => Number.parseInt(segmentId.trim(), 10))
+					.filter((segmentId) => Number.isFinite(segmentId))
+			: [];
+		const isPartial = response.headers.get("x-translation-status") === "partial";
 
 		let content = "";
 		let translatedSegmentCount = 0;
@@ -440,7 +523,7 @@ export default function Home() {
 			translatedSegmentCount += 1;
 		}
 
-		return { content, translatedSegmentCount };
+		return { content, translatedSegmentCount, blockedSegmentIds, isPartial };
 	}
 
 	function updateFileProgress(
@@ -466,6 +549,8 @@ export default function Home() {
 		translatedContent: string;
 		outputFilename: string;
 		totalBatches: number;
+		blockedSegmentIds: number[];
+		isPartialTranslation: boolean;
 	}> {
 		if (!content) {
 			throw new Error("No content provided.");
@@ -498,6 +583,8 @@ export default function Home() {
 
 		let translatedContent = "";
 		let translatedSegmentCount = 0;
+		const blockedSegmentIds = new Set<number>();
+		let isPartialTranslation = false;
 		const translationRunId = crypto.randomUUID();
 
 		for (let requestIndex = 0; requestIndex < requestGroups.length; requestIndex += 1) {
@@ -512,6 +599,12 @@ export default function Home() {
 			);
 
 			const batchResult = await handleStream(response);
+			if (batchResult.isPartial) {
+				isPartialTranslation = true;
+			}
+			for (const blockedSegmentId of batchResult.blockedSegmentIds) {
+				blockedSegmentIds.add(blockedSegmentId);
+			}
 
 			if (batchResult.translatedSegmentCount !== requestGroup.length) {
 				throw new Error(
@@ -567,7 +660,13 @@ export default function Home() {
 			throw new Error("Error occurred while reading the translated output.");
 		}
 
-		return { translatedContent, outputFilename, totalBatches: requestGroups.length };
+		return {
+			translatedContent,
+			outputFilename,
+			totalBatches: requestGroups.length,
+			blockedSegmentIds: Array.from(blockedSegmentIds),
+			isPartialTranslation,
+		};
 	}
 
 	async function finalizeBulkRun(results: FileResult[], language: string) {
@@ -636,6 +735,7 @@ export default function Home() {
 			hasIndexedItems && fileResults.length
 				? fileResults.map((result) => ({
 						...result,
+						retryable: result.retryable ?? true,
 						totalBatches: result.totalBatches ?? 0,
 						completedBatches: result.completedBatches ?? 0,
 				  }))
@@ -643,6 +743,9 @@ export default function Home() {
 						filename: item.filename,
 						content: item.content,
 						status: "pending" as const,
+						retryable: true,
+						blockedSegmentIds: [],
+						isPartialTranslation: false,
 						totalBatches: 0,
 						completedBatches: 0,
 				  }));
@@ -662,6 +765,9 @@ export default function Home() {
 					translatedContent: undefined,
 					outputFilename: undefined,
 					error: undefined,
+					retryable: true,
+					blockedSegmentIds: [],
+					isPartialTranslation: false,
 					totalBatches: 0,
 					completedBatches: 0,
 				};
@@ -700,6 +806,9 @@ export default function Home() {
 					translatedContent: undefined,
 					outputFilename: undefined,
 					error: undefined,
+					retryable: true,
+					blockedSegmentIds: [],
+					isPartialTranslation: false,
 					totalBatches: 0,
 					completedBatches: 0,
 				};
@@ -714,6 +823,9 @@ export default function Home() {
 						translatedContent: undefined,
 						outputFilename: undefined,
 						error: undefined,
+						retryable: true,
+						blockedSegmentIds: [],
+						isPartialTranslation: false,
 						totalBatches: 0,
 						completedBatches: 0,
 					};
@@ -721,7 +833,13 @@ export default function Home() {
 				});
 
 				try {
-					const { translatedContent, outputFilename, totalBatches } =
+					const {
+						translatedContent,
+						outputFilename,
+						totalBatches,
+						blockedSegmentIds,
+						isPartialTranslation,
+					} =
 						await translateSingleFile(
 						queueItem.content,
 						language,
@@ -734,6 +852,9 @@ export default function Home() {
 						translatedContent,
 						outputFilename,
 						error: undefined,
+						retryable: true,
+						blockedSegmentIds,
+						isPartialTranslation,
 						totalBatches,
 						completedBatches: totalBatches,
 					};
@@ -748,6 +869,9 @@ export default function Home() {
 							translatedContent,
 							outputFilename,
 							error: undefined,
+							retryable: true,
+							blockedSegmentIds,
+							isPartialTranslation,
 							totalBatches,
 							completedBatches: totalBatches,
 						};
@@ -757,10 +881,12 @@ export default function Home() {
 					console.error(`Translation failed for ${queueItem.filename}`, error);
 					const message =
 						error instanceof Error ? error.message : "Unknown translation error.";
+					const retryable = !(isBatchRequestError(error) && error.nonRetryable);
 					nextResults[targetIndex] = {
 						...nextResults[targetIndex],
 						status: "failed",
 						error: message,
+						retryable,
 					};
 					setFileResults((prev) => {
 						if (targetIndex < 0 || targetIndex >= prev.length) {
@@ -771,6 +897,7 @@ export default function Home() {
 							...next[targetIndex],
 							status: "failed",
 							error: message,
+							retryable,
 						};
 						return next;
 					});
@@ -818,7 +945,9 @@ export default function Home() {
 
 		const retryQueue = fileResults
 			.map((result, index) => ({ result, index }))
-			.filter(({ result }) => result.status === "failed")
+			.filter(
+				({ result }) => result.status === "failed" && result.retryable !== false,
+			)
 			.map(({ result, index }) => ({
 				filename: result.filename,
 				content: result.content,
@@ -879,6 +1008,16 @@ export default function Home() {
 	const isMultiFileRun = fileResults.length > 1;
 	const successCount = fileResults.filter((result) => result.status === "success").length;
 	const failureCount = fileResults.filter((result) => result.status === "failed").length;
+	const retryableFailureCount = fileResults.filter(
+		(result) => result.status === "failed" && result.retryable !== false,
+	).length;
+	const partialFileCount = fileResults.filter(
+		(result) => result.status === "success" && result.isPartialTranslation,
+	).length;
+	const blockedSegmentCount = fileResults.reduce(
+		(total, result) => total + (result.blockedSegmentIds?.length ?? 0),
+		0,
+	);
 
 	const titles: Record<AppMode, Record<TranslationStatus, string>> = {
 		translate: {
@@ -1103,6 +1242,16 @@ export default function Home() {
 									<span className="rounded-full border border-slate-200 bg-slate-50 px-3 py-1 text-xs font-semibold text-slate-700">
 										Duration: {formatElapsedTime(elapsedSeconds)}
 									</span>
+									{blockedSegmentCount > 0 && (
+										<span className="rounded-full border border-amber-200 bg-amber-50 px-3 py-1 text-xs font-semibold text-amber-700">
+											Blocked segments: {blockedSegmentCount}
+										</span>
+									)}
+									{partialFileCount > 0 && (
+										<span className="rounded-full border border-amber-200 bg-amber-50 px-3 py-1 text-xs font-semibold text-amber-700">
+											Partial files: {partialFileCount}
+										</span>
+									)}
 								</div>
 
 								<div className="mt-5 overflow-x-auto rounded-2xl border border-slate-200">
@@ -1131,7 +1280,11 @@ export default function Home() {
 														</span>
 													</td>
 													<td className="px-4 py-3 text-slate-500">
-														{result.status === "failed" ? result.error || "-" : "-"}
+														{result.status === "failed"
+															? result.error || "-"
+															: result.isPartialTranslation
+																? `${result.blockedSegmentIds?.length ?? 0} segment(s) could not be translated due to content restrictions.`
+																: "-"}
 													</td>
 												</tr>
 											))}
@@ -1152,14 +1305,19 @@ export default function Home() {
 										Download ZIP again
 									</button>
 								)}
-								{failureCount > 0 && (
+								{retryableFailureCount > 0 && (
 									<button
 										type="button"
 										onClick={handleRetryFailed}
 										className="inline-flex items-center justify-center rounded-xl border border-rose-300 bg-rose-50 px-4 py-2.5 text-sm font-semibold text-rose-700 transition hover:bg-rose-100"
 									>
-										Retry failed ({failureCount})
+										Retry failed ({retryableFailureCount})
 									</button>
+								)}
+								{failureCount > 0 && retryableFailureCount === 0 && (
+									<p className="rounded-xl border border-amber-200 bg-amber-50 px-4 py-2.5 text-xs font-semibold text-amber-700">
+										Failed files are not retryable without content changes.
+									</p>
 								)}
 								<button
 									type="button"

--- a/lib/content-block-handler.ts
+++ b/lib/content-block-handler.ts
@@ -1,0 +1,479 @@
+import type {
+  ProhibitedContentPolicy,
+  Segment,
+  TranslatedSegmentResult,
+  TranslationErrorCategory,
+  TranslationErrorCode,
+  TranslationErrorInfo,
+} from "@/types";
+
+const NORMAL_FINISH_REASONS = new Set(["STOP", "MAX_TOKENS", "LENGTH"]);
+
+const PROMPT_BLOCK_REASON_TO_CATEGORY: Record<string, TranslationErrorCategory> = {
+  PROHIBITED_CONTENT: "prohibited_content",
+  BLOCKED_REASON_UNSPECIFIED: "prompt_blocked",
+  OTHER: "prompt_blocked",
+};
+
+const FINISH_REASON_TO_CATEGORY: Record<string, TranslationErrorCategory> = {
+  PROHIBITED_CONTENT: "prohibited_content",
+  SAFETY: "safety_filter",
+  RECITATION: "content_filter",
+  SPII: "content_filter",
+  BLOCKLIST: "content_filter",
+  MODEL_ARMOR: "content_filter",
+  CONTENT_FILTER: "content_filter",
+  BLOCKED_REASON_UNSPECIFIED: "prompt_blocked",
+  OTHER: "prompt_blocked",
+};
+
+const CONTENT_BLOCK_CATEGORIES = new Set<TranslationErrorCategory>([
+  "prohibited_content",
+  "safety_filter",
+  "content_filter",
+  "prompt_blocked",
+]);
+
+type ErrorWithTranslationInfo = Error & {
+  translationErrorInfo?: TranslationErrorInfo;
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object";
+}
+
+function getString(value: unknown): string | undefined {
+  return typeof value === "string" ? value : undefined;
+}
+
+function normalizeReason(value: string | undefined): string | undefined {
+  if (!value) {
+    return undefined;
+  }
+
+  return value.trim().toUpperCase().replace(/[\s-]+/g, "_");
+}
+
+function getStatusCode(errorRecord: Record<string, unknown>): number | undefined {
+  const directStatus = errorRecord.statusCode;
+  if (typeof directStatus === "number" && Number.isFinite(directStatus)) {
+    return directStatus;
+  }
+
+  const cause = errorRecord.cause;
+  if (isRecord(cause)) {
+    const nestedStatus = cause.statusCode;
+    if (typeof nestedStatus === "number" && Number.isFinite(nestedStatus)) {
+      return nestedStatus;
+    }
+  }
+
+  return undefined;
+}
+
+function parseResponseBody(errorRecord: Record<string, unknown>): Record<string, unknown> | null {
+  const responseBody = errorRecord.responseBody;
+
+  if (isRecord(responseBody)) {
+    return responseBody;
+  }
+
+  if (typeof responseBody !== "string" || !responseBody.trim()) {
+    return null;
+  }
+
+  try {
+    const parsed = JSON.parse(responseBody) as unknown;
+    return isRecord(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+function extractProviderResponseId(payload: Record<string, unknown>): string | undefined {
+  const responseId = getString(payload.responseId);
+  if (responseId) {
+    return responseId;
+  }
+
+  const response = payload.response;
+  if (isRecord(response)) {
+    return getString(response.id);
+  }
+
+  return undefined;
+}
+
+function classifyPromptBlockReason(
+  reason: string | undefined,
+): TranslationErrorCategory | null {
+  if (!reason) {
+    return null;
+  }
+
+  return PROMPT_BLOCK_REASON_TO_CATEGORY[reason] ?? null;
+}
+
+function classifyFinishReasonCategory(
+  reason: string | undefined,
+): TranslationErrorCategory | null {
+  if (!reason || NORMAL_FINISH_REASONS.has(reason)) {
+    return null;
+  }
+
+  return FINISH_REASON_TO_CATEGORY[reason] ?? null;
+}
+
+function classifyFromProviderPayload(
+  payload: Record<string, unknown>,
+): { category: TranslationErrorCategory; blockReason: string; providerResponseId?: string } | null {
+  const providerResponseId = extractProviderResponseId(payload);
+
+  const promptFeedback = payload.promptFeedback;
+  if (isRecord(promptFeedback)) {
+    const promptReason = normalizeReason(getString(promptFeedback.blockReason));
+    const promptCategory = classifyPromptBlockReason(promptReason);
+    if (promptReason && promptCategory) {
+      return {
+        category: promptCategory,
+        blockReason: promptReason,
+        providerResponseId,
+      };
+    }
+  }
+
+  const directFinishReason = normalizeReason(getString(payload.finishReason));
+  const directFinishCategory = classifyFinishReasonCategory(directFinishReason);
+  if (directFinishReason && directFinishCategory) {
+    return {
+      category: directFinishCategory,
+      blockReason: directFinishReason,
+      providerResponseId,
+    };
+  }
+
+  const candidates = payload.candidates;
+  if (Array.isArray(candidates)) {
+    for (const candidate of candidates) {
+      if (!isRecord(candidate)) {
+        continue;
+      }
+
+      const candidateReason = normalizeReason(getString(candidate.finishReason));
+      const candidateCategory = classifyFinishReasonCategory(candidateReason);
+      if (candidateReason && candidateCategory) {
+        return {
+          category: candidateCategory,
+          blockReason: candidateReason,
+          providerResponseId,
+        };
+      }
+    }
+  }
+
+  return null;
+}
+
+function buildContentBlockInfo(
+  category: TranslationErrorCategory,
+  blockReason: string,
+  message: string,
+  providerResponseId?: string,
+): TranslationErrorInfo {
+  return {
+    category,
+    retryable: false,
+    splittable: true,
+    blockReason,
+    providerResponseId,
+    message,
+  };
+}
+
+function extractCauseChain(errorRecord: Record<string, unknown>): Record<string, unknown>[] {
+  const causes: Record<string, unknown>[] = [];
+  let cursor: unknown = errorRecord.cause;
+
+  while (isRecord(cursor)) {
+    causes.push(cursor);
+    cursor = cursor.cause;
+  }
+
+  return causes;
+}
+
+function containsOneOf(target: string, needles: string[]): string | undefined {
+  const normalizedTarget = target.toUpperCase();
+  return needles.find((needle) => normalizedTarget.includes(needle));
+}
+
+function getErrorMessage(error: unknown): string {
+  if (error instanceof Error) {
+    return error.message;
+  }
+  if (typeof error === "string") {
+    return error;
+  }
+  return "Unknown translation error.";
+}
+
+function toErrorInstance(error: unknown): ErrorWithTranslationInfo {
+  if (error instanceof Error) {
+    return error as ErrorWithTranslationInfo;
+  }
+
+  return new Error(getErrorMessage(error));
+}
+
+export function isContentBlockCategory(category: TranslationErrorCategory): boolean {
+  return CONTENT_BLOCK_CATEGORIES.has(category);
+}
+
+export function classifyFinishReason(
+  finishReason: string | null | undefined,
+  providerResponseId?: string,
+): TranslationErrorInfo | null {
+  const normalizedReason = normalizeReason(finishReason ?? undefined);
+  if (!normalizedReason) {
+    return null;
+  }
+
+  const category = classifyFinishReasonCategory(normalizedReason);
+  if (!category) {
+    return null;
+  }
+
+  return buildContentBlockInfo(
+    category,
+    normalizedReason,
+    `Model finished with ${normalizedReason}.`,
+    providerResponseId,
+  );
+}
+
+export function classifyTranslationError(error: unknown): TranslationErrorInfo {
+  const attachedInfo = getTranslationErrorInfo(error);
+  if (attachedInfo) {
+    return attachedInfo;
+  }
+
+  const message = getErrorMessage(error);
+  if (!isRecord(error)) {
+    return {
+      category: "unknown",
+      retryable: true,
+      splittable: false,
+      message,
+    };
+  }
+
+  const errorRecord = error;
+  const payloadCandidates: Record<string, unknown>[] = [];
+
+  const parsedBody = parseResponseBody(errorRecord);
+  if (parsedBody) {
+    payloadCandidates.push(parsedBody);
+  }
+
+  const causes = extractCauseChain(errorRecord);
+  for (const cause of causes) {
+    const parsedCauseBody = parseResponseBody(cause);
+    if (parsedCauseBody) {
+      payloadCandidates.push(parsedCauseBody);
+    }
+
+    const causeValue = cause.value;
+    if (isRecord(causeValue)) {
+      payloadCandidates.push(causeValue);
+    }
+  }
+
+  const directValue = errorRecord.value;
+  if (isRecord(directValue)) {
+    payloadCandidates.push(directValue);
+  }
+
+  for (const payload of payloadCandidates) {
+    const providerClassification = classifyFromProviderPayload(payload);
+    if (providerClassification) {
+      return buildContentBlockInfo(
+        providerClassification.category,
+        providerClassification.blockReason,
+        message,
+        providerClassification.providerResponseId,
+      );
+    }
+  }
+
+  const responseBody = getString(errorRecord.responseBody) ?? "";
+  const fallbackText = `${message}\n${responseBody}`.toUpperCase();
+
+  const matchedPromptReason = containsOneOf(fallbackText, [
+    "PROHIBITED_CONTENT",
+    "BLOCKED_REASON_UNSPECIFIED",
+    "SAFETY",
+    "RECITATION",
+    "SPII",
+    "BLOCKLIST",
+    "MODEL_ARMOR",
+    "CONTENT_FILTER",
+  ]);
+
+  if (matchedPromptReason) {
+    const normalizedReason = normalizeReason(matchedPromptReason);
+    const category =
+      classifyPromptBlockReason(normalizedReason) ??
+      classifyFinishReasonCategory(normalizedReason) ??
+      "content_filter";
+    if (normalizedReason) {
+      return buildContentBlockInfo(category, normalizedReason, message);
+    }
+  }
+
+  if (
+    /expected\s+\d+\s+segments?.*received\s+\d+/i.test(message) ||
+    /unexpected translated output shape/i.test(message)
+  ) {
+    return {
+      category: "segment_mismatch",
+      retryable: true,
+      splittable: false,
+      message,
+    };
+  }
+
+  const errorName = getString(errorRecord.name) ?? "";
+  const errorCode = getString(errorRecord.code) ?? "";
+  if (
+    errorName === "AbortError" ||
+    errorCode === "ABORT_ERR" ||
+    /timed?\s*out/i.test(message) ||
+    /aborted/i.test(message)
+  ) {
+    return {
+      category: "timeout",
+      retryable: true,
+      splittable: false,
+      message,
+    };
+  }
+
+  const statusCode = getStatusCode(errorRecord);
+  if (statusCode === 429 || (statusCode !== undefined && statusCode >= 500 && statusCode < 600)) {
+    return {
+      category: "transient",
+      retryable: true,
+      splittable: false,
+      message,
+    };
+  }
+
+  if (
+    errorName === "TypeError" &&
+    /(fetch failed|network|econn|socket|connection|enotfound|eai_again)/i.test(message)
+  ) {
+    return {
+      category: "network",
+      retryable: true,
+      splittable: false,
+      message,
+    };
+  }
+
+  return {
+    category: "unknown",
+    retryable: true,
+    splittable: false,
+    message,
+  };
+}
+
+export function attachTranslationErrorInfo(
+  error: unknown,
+  info: TranslationErrorInfo,
+): ErrorWithTranslationInfo {
+  const errorInstance = toErrorInstance(error);
+  errorInstance.translationErrorInfo = info;
+  return errorInstance;
+}
+
+export function getTranslationErrorInfo(error: unknown): TranslationErrorInfo | null {
+  if (!isRecord(error)) {
+    return null;
+  }
+
+  const candidate = error.translationErrorInfo;
+  if (!isRecord(candidate)) {
+    return null;
+  }
+
+  const category = candidate.category;
+  const retryable = candidate.retryable;
+  const splittable = candidate.splittable;
+  const message = candidate.message;
+
+  if (
+    typeof category === "string" &&
+    typeof retryable === "boolean" &&
+    typeof splittable === "boolean" &&
+    typeof message === "string"
+  ) {
+    return {
+      category: category as TranslationErrorCategory,
+      retryable,
+      splittable,
+      blockReason: getString(candidate.blockReason),
+      providerResponseId: getString(candidate.providerResponseId),
+      message,
+    };
+  }
+
+  return null;
+}
+
+export function translationErrorCategoryToCode(
+  category: TranslationErrorCategory,
+): TranslationErrorCode {
+  switch (category) {
+    case "prohibited_content":
+      return "PROHIBITED_CONTENT";
+    case "safety_filter":
+      return "SAFETY_FILTER";
+    case "content_filter":
+      return "CONTENT_FILTER";
+    case "prompt_blocked":
+      return "PROMPT_BLOCKED";
+    default:
+      return "TRANSLATION_ERROR";
+  }
+}
+
+export function applyIrreducibleBlockPolicy(
+  segment: Segment,
+  policy: ProhibitedContentPolicy,
+  placeholder: string,
+  blockReason?: string,
+): TranslatedSegmentResult {
+  let text: string;
+
+  switch (policy) {
+    case "placeholder":
+      text = placeholder;
+      break;
+    case "redact":
+      text = "";
+      break;
+    case "keep_original":
+    default:
+      text = segment.text;
+      break;
+  }
+
+  return {
+    text,
+    blocked: true,
+    originalSegmentId: segment.id,
+    blockReason,
+    blockPolicy: policy,
+  };
+}

--- a/lib/translation-config.ts
+++ b/lib/translation-config.ts
@@ -1,3 +1,5 @@
+import type { ProhibitedContentPolicy } from "@/types";
+
 const DEFAULT_GEMINI_MODEL_NAME = "gemini-3-flash-preview";
 const DEFAULT_GEMINI_BATCH_TOKENS = 350;
 const MIN_GEMINI_BATCH_TOKENS = 100;
@@ -7,6 +9,16 @@ const MIN_MAX_PARALLEL = 1;
 const MAX_MAX_PARALLEL = 20;
 const GEMINI_THINKING_LEVELS = ["minimal", "low", "medium", "high"] as const;
 const DEFAULT_GEMINI_THINKING_LEVEL = "low";
+const PROHIBITED_CONTENT_POLICIES = [
+	"keep_original",
+	"placeholder",
+	"redact",
+] as const;
+const DEFAULT_PROHIBITED_CONTENT_POLICY: ProhibitedContentPolicy = "keep_original";
+const DEFAULT_PROHIBITED_CONTENT_PLACEHOLDER = "[Content not available]";
+const DEFAULT_MAX_SPLIT_DEPTH = 5;
+const MIN_MAX_SPLIT_DEPTH = 1;
+const MAX_MAX_SPLIT_DEPTH = 10;
 
 export type GeminiThinkingLevel = (typeof GEMINI_THINKING_LEVELS)[number];
 
@@ -16,6 +28,9 @@ export type TranslationRuntimeConfig = {
 	maxParallel: number;
 	thinkingLevel: GeminiThinkingLevel;
 	isGemini3Model: boolean;
+	prohibitedContentPolicy: ProhibitedContentPolicy;
+	prohibitedContentPlaceholder: string;
+	maxSplitDepth: number;
 };
 
 type TranslationRuntimeConfigResult = {
@@ -37,6 +52,10 @@ function isGeminiThinkingLevel(value: string): value is GeminiThinkingLevel {
 	return GEMINI_THINKING_LEVELS.includes(value as GeminiThinkingLevel);
 }
 
+function isProhibitedContentPolicy(value: string): value is ProhibitedContentPolicy {
+	return PROHIBITED_CONTENT_POLICIES.includes(value as ProhibitedContentPolicy);
+}
+
 export function resolveTranslationRuntimeConfig(): TranslationRuntimeConfigResult {
 	const modelName =
 		getFirstDefinedEnvValue(["GEMINI_MODEL_NAME"]) || DEFAULT_GEMINI_MODEL_NAME;
@@ -53,6 +72,9 @@ export function resolveTranslationRuntimeConfig(): TranslationRuntimeConfigResul
 					maxParallel: DEFAULT_MAX_PARALLEL,
 					thinkingLevel,
 					isGemini3Model,
+					prohibitedContentPolicy: DEFAULT_PROHIBITED_CONTENT_POLICY,
+					prohibitedContentPlaceholder: DEFAULT_PROHIBITED_CONTENT_PLACEHOLDER,
+					maxSplitDepth: DEFAULT_MAX_SPLIT_DEPTH,
 				},
 				error:
 					'Invalid GEMINI_THINKING_LEVEL value. Use one of: "minimal", "low", "medium", "high".',
@@ -74,6 +96,9 @@ export function resolveTranslationRuntimeConfig(): TranslationRuntimeConfigResul
 					maxParallel: DEFAULT_MAX_PARALLEL,
 					thinkingLevel,
 					isGemini3Model,
+					prohibitedContentPolicy: DEFAULT_PROHIBITED_CONTENT_POLICY,
+					prohibitedContentPlaceholder: DEFAULT_PROHIBITED_CONTENT_PLACEHOLDER,
+					maxSplitDepth: DEFAULT_MAX_SPLIT_DEPTH,
 				},
 				error:
 					"Invalid GEMINI_BATCH_TOKENS value. Use an integer between 100 and 2000.",
@@ -87,6 +112,9 @@ export function resolveTranslationRuntimeConfig(): TranslationRuntimeConfigResul
 					maxParallel: DEFAULT_MAX_PARALLEL,
 					thinkingLevel,
 					isGemini3Model,
+					prohibitedContentPolicy: DEFAULT_PROHIBITED_CONTENT_POLICY,
+					prohibitedContentPlaceholder: DEFAULT_PROHIBITED_CONTENT_PLACEHOLDER,
+					maxSplitDepth: DEFAULT_MAX_SPLIT_DEPTH,
 				},
 				error:
 					"Invalid GEMINI_BATCH_TOKENS value. Use an integer between 100 and 2000.",
@@ -108,6 +136,46 @@ export function resolveTranslationRuntimeConfig(): TranslationRuntimeConfigResul
 		}
 	}
 
+	const prohibitedContentPolicyRaw = getFirstDefinedEnvValue([
+		"PROHIBITED_CONTENT_POLICY",
+	]);
+	let prohibitedContentPolicy = DEFAULT_PROHIBITED_CONTENT_POLICY;
+	if (prohibitedContentPolicyRaw) {
+		if (isProhibitedContentPolicy(prohibitedContentPolicyRaw)) {
+			prohibitedContentPolicy = prohibitedContentPolicyRaw;
+		} else {
+			console.warn(
+				`Invalid PROHIBITED_CONTENT_POLICY value "${prohibitedContentPolicyRaw}". Falling back to "${DEFAULT_PROHIBITED_CONTENT_POLICY}".`,
+			);
+		}
+	}
+
+	const prohibitedContentPlaceholderRaw = process.env.PROHIBITED_CONTENT_PLACEHOLDER;
+	const prohibitedContentPlaceholder =
+		typeof prohibitedContentPlaceholderRaw === "string" &&
+		prohibitedContentPlaceholderRaw.trim().length > 0
+			? prohibitedContentPlaceholderRaw
+			: DEFAULT_PROHIBITED_CONTENT_PLACEHOLDER;
+
+	const maxSplitDepthRaw = getFirstDefinedEnvValue([
+		"PROHIBITED_CONTENT_MAX_SPLIT_DEPTH",
+	]);
+	let maxSplitDepth = DEFAULT_MAX_SPLIT_DEPTH;
+	if (maxSplitDepthRaw) {
+		const parsed = Number.parseInt(maxSplitDepthRaw, 10);
+		if (
+			Number.isFinite(parsed) &&
+			parsed >= MIN_MAX_SPLIT_DEPTH &&
+			parsed <= MAX_MAX_SPLIT_DEPTH
+		) {
+			maxSplitDepth = parsed;
+		} else {
+			console.warn(
+				`Invalid PROHIBITED_CONTENT_MAX_SPLIT_DEPTH value "${maxSplitDepthRaw}". Falling back to ${DEFAULT_MAX_SPLIT_DEPTH}.`,
+			);
+		}
+	}
+
 	return {
 		config: {
 			modelName,
@@ -115,6 +183,9 @@ export function resolveTranslationRuntimeConfig(): TranslationRuntimeConfigResul
 			maxParallel,
 			thinkingLevel,
 			isGemini3Model,
+			prohibitedContentPolicy,
+			prohibitedContentPlaceholder,
+			maxSplitDepth,
 		},
 		error: null,
 	};

--- a/types.ts
+++ b/types.ts
@@ -9,4 +9,54 @@ export type Segment = {
   id: number;
   timestamp: string;
   text: string;
-}
+};
+
+export type ProhibitedContentPolicy =
+  | "keep_original"
+  | "placeholder"
+  | "redact";
+
+export type TranslationErrorCategory =
+  | "prohibited_content"
+  | "safety_filter"
+  | "content_filter"
+  | "prompt_blocked"
+  | "segment_mismatch"
+  | "timeout"
+  | "transient"
+  | "network"
+  | "unknown";
+
+export type TranslationErrorInfo = {
+  category: TranslationErrorCategory;
+  retryable: boolean;
+  splittable: boolean;
+  blockReason?: string;
+  providerResponseId?: string;
+  message: string;
+};
+
+export type TranslationErrorCode =
+  | "PROHIBITED_CONTENT"
+  | "SAFETY_FILTER"
+  | "CONTENT_FILTER"
+  | "PROMPT_BLOCKED"
+  | "TRANSLATION_ERROR"
+  | "INVALID_REQUEST"
+  | "CONFIG_ERROR";
+
+export type TranslatedSegmentResult = {
+  text: string;
+  blocked: boolean;
+  originalSegmentId: number;
+  blockReason?: string;
+  blockPolicy?: ProhibitedContentPolicy;
+};
+
+export type TranslationGroupResult = {
+  segments: TranslatedSegmentResult[];
+  hasBlockedSegments: boolean;
+  blockedSegmentIds: number[];
+  blockedReasons: string[];
+  splitDepth: number;
+};


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add robust translation error classification for Gemini prompt-level and finish-reason content blocks (including `PROHIBITED_CONTENT`, `SAFETY`, `RECITATION`, `SPII`, `BLOCKLIST`, and `MODEL_ARMOR`)
- replace streaming server response flow with buffered group orchestration so final response headers can include complete blocked-segment metadata
- implement adaptive binary split fallback for splittable content-block errors and apply configurable irreducible-segment policy (`keep_original`, `placeholder`, `redact`)
- expose new runtime config fields and env vars for prohibited-content behavior and max split depth
- update client batch/request handling to consume partial-translation headers, surface blocked segment warnings, and skip retries for non-retryable content-block error codes

## API contract updates
- success responses now include `x-translation-status` (`complete` or `partial`)
- partial responses include `x-translation-blocked-segments` and `x-translation-blocked-reasons`
- structured error responses include `code` and `blockReasons` (when available)

## Validation
- `npm run lint`
- `npm run build`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3cb02d1c-ad86-4cc1-9cd1-79202e3b9f83"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3cb02d1c-ad86-4cc1-9cd1-79202e3b9f83"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

